### PR TITLE
Changes to cargo to allow to depend only on the base client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,9 @@ proptest-derive = { optional = true, version = "0.4.0" }
 rand = { version = "0.8" }
 serde_json = { features = [ "float_roundtrip", "preserve_order" ], version = "1" }
 thiserror = { version = "1" }
-tokio = { features = [ "full" ], version = "1" }
+tokio = { optional = true, features = [ "sync" ], version = "1" }
 tokio-stream = { features = [ "io-util", "sync" ], version = "^0.1.8" }
-tokio-tungstenite = { version = "0.20.0" }
+tokio-tungstenite = { optional = true, version = "0.20.0" }
 tracing = { version = "0.1" }
 url = { version = "2" }
 uuid = { features = [ "serde", "v4" ], version = "1.6" }
@@ -43,9 +43,12 @@ proptest-derive = { version = "0.4.0" }
 tracing-subscriber = { features = [ "env-filter" ], version = "0.3.17" }
 
 [features]
-default = [ "native-tls" ]
-native-tls = [ "tokio-tungstenite/native-tls" ]
-native-tls-vendored = [ "tokio-tungstenite/native-tls-vendored" ]
-rustls-tls-native-roots = [ "tokio-tungstenite/rustls-tls-native-roots" ]
-rustls-tls-webpki-roots = [ "tokio-tungstenite/rustls-tls-webpki-roots" ]
-testing = [ "convex_sync_types/testing", "proptest", "proptest-derive", "parking_lot" ]
+default = [ "full", "native-tls" ]
+native-tls = [ "full", "tokio-tungstenite/native-tls" ]
+native-tls-vendored = [ "full", "tokio-tungstenite/native-tls-vendored" ]
+rustls-tls-native-roots = [ "full", "tokio-tungstenite/rustls-tls-native-roots" ]
+rustls-tls-webpki-roots = [ "full", "tokio-tungstenite/rustls-tls-webpki-roots" ]
+testing = [ "full", "convex_sync_types/testing", "proptest", "proptest-derive", "parking_lot" ]
+full = [ "full-client", "base-client" ]
+full-client = [ "tokio-tungstenite", "tokio/full"]
+base-client = ["tokio/sync"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,3 +73,6 @@ pub use base_client::{
 };
 
 mod sync;
+
+
+pub use convex_sync_types;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,10 @@ pub use value::{
     Value,
 };
 
+#[cfg(any(feature = "full-client"))]
 mod client;
+
+#[cfg(any(feature = "full-client"))]
 pub use client::{
     subscription::{
         QuerySetSubscription,
@@ -58,7 +61,10 @@ pub use client::{
     ConvexClient,
 };
 
+#[cfg(any(feature = "base-client"))]
 pub mod base_client;
+
+#[cfg(any(feature = "base-client"))]
 #[doc(inline)]
 pub use base_client::{
     FunctionResult,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,8 +74,7 @@ pub use base_client::{
 
 mod sync;
 
-mod convex_sync_types;
+pub mod convex_sync_types;
 pub use convex_sync_types::{
-    ClientMessage,
-    Timestamp,
+    UdfPath, ServerMessage
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,8 +73,3 @@ pub use base_client::{
 };
 
 mod sync;
-
-pub mod convex_sync_types;
-pub use convex_sync_types::{
-    UdfPath, ServerMessage
-};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,5 +74,8 @@ pub use base_client::{
 
 mod sync;
 
-
-pub use convex_sync_types;
+mod convex_sync_types;
+pub use convex_sync_types::{
+    ClientMessage,
+    Timestamp,
+};

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -10,6 +10,7 @@ use crate::value::Value;
 
 #[cfg(test)]
 pub mod testing;
+#[cfg(any(feature = "full-client"))]
 pub mod web_socket_manager;
 
 /// Upon a protocol failure, an explanation of the failure to pass in on


### PR DESCRIPTION
<!-- Describe your PR here. -->
Made some small changes in the feature flags so that it is possible to compile or depend only on the base client. 

I am building a [Godot client] and want to keep the ability to compile cross-platform, including web. The full client version of `convex-rs` depends on libraries that cannot be compiled to wasm. 


<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
