### PR TITLE
Don't require native-tls-vendored in tokio-tungstenite unless requested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Upcoming
 
+# 0.8.1
+
+- Fix convex-mobile build by not always compiling native-tls-vendored for
+  tokio-tungstenite regardless of requested features
+
 # 0.8.0
 
 - Support for passing through a client_id to ConvexClient

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "convex"
 description = "Client library for Convex (convex.dev)"
 authors = [ "Convex, Inc. <no-reply@convex.dev>" ]
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 rust-version = "1.65.0"
 resolver = "2"
@@ -26,7 +26,7 @@ serde_json = { features = [ "float_roundtrip", "preserve_order" ], version = "1"
 thiserror = { version = "1" }
 tokio = { features = [ "full" ], version = "1" }
 tokio-stream = { features = [ "io-util", "sync" ], version = "0.1" }
-tokio-tungstenite = { version = "0.21.0", features = [ "native-tls-vendored" ] }
+tokio-tungstenite = { version = "0.21.0"}
 tracing = { version = "0.1" }
 url = { version = "2.5.2" }
 uuid = { features = [ "serde", "v4" ], version = "1.6" }


### PR DESCRIPTION
It will get required if one builds with the native-tls-vendored feature, which is actually the default feature for convex-rs.

<!-- Describe your PR here. -->



<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
