### PR TITLE
Socket Monitor + ConvexClientBuilder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "convex"
 description = "Client library for Convex (convex.dev)"
 authors = [ "Convex, Inc. <no-reply@convex.dev>" ]
-version = "0.8.1"
+version = "0.9.0"
 edition = "2021"
 rust-version = "1.70.0"
 resolver = "2"

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,23 +1,11 @@
-use std::{
-    collections::BTreeMap,
-    convert::Infallible,
-    sync::Arc,
-};
+use std::{collections::BTreeMap, convert::Infallible, sync::Arc};
 
-use convex_sync_types::{
-    AuthenticationToken,
-    UdfPath,
-    UserIdentityAttributes,
-};
+use convex_sync_types::{AuthenticationToken, UdfPath, UserIdentityAttributes};
 #[cfg(doc)]
 use futures::Stream;
 use futures::StreamExt;
 use tokio::{
-    sync::{
-        broadcast,
-        mpsc,
-        oneshot,
-    },
+    sync::{broadcast, mpsc, oneshot},
     task::JoinHandle,
 };
 use tokio_stream::wrappers::BroadcastStream;
@@ -27,28 +15,12 @@ use self::worker::AuthenticateRequest;
 #[cfg(doc)]
 use crate::SubscriberId;
 use crate::{
-    base_client::{
-        BaseConvexClient,
-        QueryResults,
-    },
+    base_client::{BaseConvexClient, QueryResults},
     client::{
-        subscription::{
-            QuerySetSubscription,
-            QuerySubscription,
-        },
-        worker::{
-            worker,
-            ActionRequest,
-            ClientRequest,
-            MutationRequest,
-            SubscribeRequest,
-        },
+        subscription::{QuerySetSubscription, QuerySubscription},
+        worker::{worker, ActionRequest, ClientRequest, MutationRequest, SubscribeRequest},
     },
-    sync::{
-        web_socket_manager::WebSocketManager,
-        SyncProtocol,
-        WebSocketState,
-    },
+    sync::{web_socket_manager::WebSocketManager, SyncProtocol, WebSocketState},
     value::Value,
     FunctionResult,
 };
@@ -119,7 +91,7 @@ impl Drop for ConvexClient {
 }
 
 impl ConvexClient {
-    /// Create a new [`ConvexClient`] connected to the given deployment URL.
+    /// Constructs a new client for communicating with `deployment_url`.
     ///
     /// ```no_run
     /// # use convex::ConvexClient;
@@ -418,7 +390,7 @@ impl ConvexClientBuilder {
         self
     }
 
-    /// Set a custom on_state_change callback for this client.
+    /// Set a channel to be notified of changes to the WebSocket connection state.
     pub fn with_on_state_change(mut self, on_state_change: mpsc::Sender<WebSocketState>) -> Self {
         self.on_state_change = Some(on_state_change);
         self
@@ -439,56 +411,25 @@ impl ConvexClientBuilder {
     }
 }
 
-impl ConvexClient {
-    /// Create a new [`ConvexClientBuilder`] to configure a client.
-    pub fn builder(deployment_url: &str) -> ConvexClientBuilder {
-        ConvexClientBuilder::new(deployment_url)
-    }
-}
-
 #[cfg(test)]
 pub mod tests {
-    use std::{
-        str::FromStr,
-        sync::Arc,
-        time::Duration,
-    };
+    use std::{str::FromStr, sync::Arc, time::Duration};
 
     use convex_sync_types::{
-        AuthenticationToken,
-        ClientMessage,
-        LogLinesMessage,
-        Query,
-        QueryId,
-        QuerySetModification,
-        SessionId,
-        StateModification,
-        StateVersion,
-        UdfPath,
-        UserIdentityAttributes,
+        AuthenticationToken, ClientMessage, LogLinesMessage, Query, QueryId, QuerySetModification,
+        SessionId, StateModification, StateVersion, UdfPath, UserIdentityAttributes,
     };
     use futures::StreamExt;
     use maplit::btreemap;
     use pretty_assertions::assert_eq;
     use serde_json::json;
-    use tokio::sync::{
-        broadcast,
-        mpsc,
-    };
+    use tokio::sync::{broadcast, mpsc};
 
     use super::ConvexClient;
     use crate::{
         base_client::FunctionResult,
-        client::{
-            deployment_to_ws_url,
-            worker::worker,
-            BaseConvexClient,
-        },
-        sync::{
-            testing::TestProtocolManager,
-            ServerMessage,
-            SyncProtocol,
-        },
+        client::{deployment_to_ws_url, worker::worker, BaseConvexClient},
+        sync::{testing::TestProtocolManager, ServerMessage, SyncProtocol},
         value::Value,
     };
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -47,6 +47,7 @@ use crate::{
     sync::{
         web_socket_manager::WebSocketManager,
         SyncProtocol,
+        WebSocketState,
     },
     value::Value,
     FunctionResult,
@@ -118,7 +119,7 @@ impl Drop for ConvexClient {
 }
 
 impl ConvexClient {
-    /// Constructs a new client for communicating with `deployment_url`.
+    /// Create a new [`ConvexClient`] connected to the given deployment URL.
     ///
     /// ```no_run
     /// # use convex::ConvexClient;
@@ -129,13 +130,15 @@ impl ConvexClient {
     /// # }
     /// ```
     pub async fn new(deployment_url: &str) -> anyhow::Result<Self> {
-        let client_id = format!("rust-{}", VERSION.unwrap_or("unknown"));
-        Self::new_with_client_id(deployment_url, &client_id).await
+        ConvexClient::new_from_builder(ConvexClientBuilder::new(deployment_url)).await
     }
 
     #[doc(hidden)]
-    pub async fn new_with_client_id(deployment_url: &str, client_id: &str) -> anyhow::Result<Self> {
-        let ws_url = deployment_to_ws_url(deployment_url.try_into()?)?;
+    pub async fn new_from_builder(builder: ConvexClientBuilder) -> anyhow::Result<Self> {
+        let client_id = builder
+            .client_id
+            .unwrap_or_else(|| format!("rust-{}", VERSION.unwrap_or("unknown")));
+        let ws_url = deployment_to_ws_url(builder.deployment_url.as_str().try_into()?)?;
 
         // Channels for the `listen` background thread
         let (response_sender, response_receiver) = mpsc::channel(1);
@@ -146,7 +149,13 @@ impl ConvexClient {
 
         let base_client = BaseConvexClient::new();
 
-        let protocol = WebSocketManager::open(ws_url, response_sender, client_id).await?;
+        let protocol = WebSocketManager::open(
+            ws_url,
+            response_sender,
+            builder.on_state_change,
+            client_id.as_str(),
+        )
+        .await?;
 
         let listen_handle = tokio::spawn(worker(
             response_receiver,
@@ -386,6 +395,57 @@ fn deployment_to_ws_url(mut deployment_url: Url) -> anyhow::Result<Url> {
     Ok(deployment_url)
 }
 
+/// A builder for creating a [`ConvexClient`] with custom configuration.
+pub struct ConvexClientBuilder {
+    deployment_url: String,
+    client_id: Option<String>,
+    on_state_change: Option<mpsc::Sender<WebSocketState>>,
+}
+
+impl ConvexClientBuilder {
+    /// Create a new [`ConvexClientBuilder`] with the given deployment URL.
+    pub fn new(deployment_url: &str) -> Self {
+        Self {
+            deployment_url: deployment_url.to_string(),
+            client_id: None,
+            on_state_change: None,
+        }
+    }
+
+    /// Set a custom client ID for this client.
+    pub fn with_client_id(mut self, client_id: &str) -> Self {
+        self.client_id = Some(client_id.to_string());
+        self
+    }
+
+    /// Set a custom on_state_change callback for this client.
+    pub fn with_on_state_change(mut self, on_state_change: mpsc::Sender<WebSocketState>) -> Self {
+        self.on_state_change = Some(on_state_change);
+        self
+    }
+
+    /// Build the [`ConvexClient`] with the configured options.
+    ///
+    /// ```no_run
+    /// # use convex::ConvexClientBuilder;
+    /// # #[tokio::main]
+    /// # async fn main() -> anyhow::Result<()> {
+    /// let client = ConvexClientBuilder::new("https://cool-music-123.convex.cloud").build().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn build(self) -> anyhow::Result<ConvexClient> {
+        ConvexClient::new_from_builder(self).await
+    }
+}
+
+impl ConvexClient {
+    /// Create a new [`ConvexClientBuilder`] to configure a client.
+    pub fn builder(deployment_url: &str) -> ConvexClientBuilder {
+        ConvexClientBuilder::new(deployment_url)
+    }
+}
+
 #[cfg(test)]
 pub mod tests {
     use std::{
@@ -445,9 +505,13 @@ pub mod tests {
             // Listener for when each transaction completes
             let (watch_sender, watch_receiver) = broadcast::channel(1);
 
-            let test_protocol =
-                TestProtocolManager::open("ws://test.com".parse()?, response_sender, "rust-0.0.1")
-                    .await?;
+            let test_protocol = TestProtocolManager::open(
+                "ws://test.com".parse()?,
+                response_sender,
+                None,
+                "rust-0.0.1",
+            )
+            .await?;
             let base_client = BaseConvexClient::new();
 
             let listen_handle = tokio::spawn(worker(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,9 @@ pub use client::{
         QuerySubscription,
     },
     ConvexClient,
+    ConvexClientBuilder,
 };
+pub use sync::WebSocketState;
 
 pub mod base_client;
 #[doc(inline)]

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -30,11 +30,21 @@ pub enum ProtocolResponse {
     Failure,
 }
 
+#[derive(Debug)]
+/// The state of the Convex WebSocket connection
+pub enum WebSocketState {
+    /// The WebSocket is open and connected
+    Connected,
+    /// The WebSocket is closed and reconnecting
+    Reconnecting,
+}
+
 #[async_trait]
 pub trait SyncProtocol: Send + Sized {
     async fn open(
         ws_url: Url,
         on_response: mpsc::Sender<ProtocolResponse>,
+        on_state_change: Option<mpsc::Sender<WebSocketState>>,
         client_id: &str,
     ) -> anyhow::Result<Self>;
     async fn send(&mut self, message: ClientMessage) -> anyhow::Result<()>;

--- a/src/sync/testing.rs
+++ b/src/sync/testing.rs
@@ -14,7 +14,10 @@ use tokio::sync::mpsc;
 use url::Url;
 use uuid::Uuid;
 
-use super::ReconnectRequest;
+use super::{
+    ReconnectRequest,
+    WebSocketState,
+};
 use crate::sync::{
     ProtocolResponse,
     ServerMessage,
@@ -60,6 +63,7 @@ impl SyncProtocol for TestProtocolManager {
     async fn open(
         _ws_url: Url,
         response_sender: mpsc::Sender<ProtocolResponse>,
+        _on_state_change: Option<mpsc::Sender<WebSocketState>>,
         _client_id: &str,
     ) -> anyhow::Result<Self> {
         let mut test_protocol = TestProtocolManager {

--- a/src/sync/web_socket_manager.rs
+++ b/src/sync/web_socket_manager.rs
@@ -49,6 +49,7 @@ use tokio_tungstenite::{
 use url::Url;
 use uuid::Uuid;
 
+use super::WebSocketState;
 use crate::sync::{
     ProtocolResponse,
     ReconnectRequest,
@@ -73,6 +74,7 @@ struct WebSocketInternal {
 struct WebSocketWorker {
     ws_url: Url,
     on_response: mpsc::Sender<ProtocolResponse>,
+    on_state_change: Option<mpsc::Sender<WebSocketState>>,
     internal_receiver: Fuse<UnboundedReceiverStream<WebSocketRequest>>,
     ping_ticker: Interval,
     connection_count: u32,
@@ -94,12 +96,14 @@ impl SyncProtocol for WebSocketManager {
     async fn open(
         ws_url: Url,
         on_response: mpsc::Sender<ProtocolResponse>,
+        on_state_change: Option<mpsc::Sender<WebSocketState>>,
         client_id: &str,
     ) -> anyhow::Result<Self> {
         let (internal_sender, internal_receiver) = mpsc::unbounded_channel();
         let worker_handle = tokio::spawn(WebSocketWorker::run(
             ws_url,
             on_response,
+            on_state_change,
             internal_receiver,
             client_id.to_string(),
         ));
@@ -134,6 +138,7 @@ impl WebSocketWorker {
     async fn run(
         ws_url: Url,
         on_response: mpsc::Sender<ProtocolResponse>,
+        on_state_change: Option<mpsc::Sender<WebSocketState>>,
         internal_receiver: mpsc::UnboundedReceiver<WebSocketRequest>,
         client_id: String,
     ) -> Infallible {
@@ -143,6 +148,7 @@ impl WebSocketWorker {
         let mut worker = Self {
             ws_url,
             on_response,
+            on_state_change,
             internal_receiver: UnboundedReceiverStream::new(internal_receiver).fuse(),
             ping_ticker,
             connection_count: 0,
@@ -151,11 +157,19 @@ impl WebSocketWorker {
 
         let mut last_close_reason = "InitialConnect".to_string();
         let mut max_observed_timestamp = None;
+        if let Some(state_change_sender) = &worker.on_state_change {
+            let _ = state_change_sender.try_send(WebSocketState::Reconnecting);
+        }
         loop {
-            let e = match worker
+            let exit_result = worker
                 .work(last_close_reason, max_observed_timestamp, &client_id)
-                .await
-            {
+                .await;
+
+            if let Some(state_change_sender) = &worker.on_state_change {
+                let _ = state_change_sender.try_send(WebSocketState::Reconnecting);
+            }
+
+            let e = match exit_result {
                 Ok(reconnect) => {
                     // WS worker exited cleanly because it got a request to reconnect
                     tracing::debug!("Reconnecting websocket due to {}", reconnect.reason);
@@ -218,6 +232,9 @@ impl WebSocketWorker {
         )
         .await?;
         tracing::debug!("completed websocket {verb} to {}", self.ws_url);
+        if let Some(state_change_sender) = &self.on_state_change {
+            let _ = state_change_sender.try_send(WebSocketState::Connected);
+        }
 
         loop {
             select_biased! {


### PR DESCRIPTION
<!-- Describe your PR here. -->

Add the optional ability to provide a `mpsc::sync::Sender` for websocket status updates. This allows the calling application to monitor socket connectedness status.

Since this is yet another option for constructing a client, I introduced a builder pattern so we don't get to ugly with combinatorial explosion.