### PR TITLE
Add #[must_use] to FunctionResult

### DIFF
--- a/src/base_client/query_result.rs
+++ b/src/base_client/query_result.rs
@@ -17,6 +17,7 @@ use crate::{
 ///
 /// The function returns a Convex value or an error message string.
 #[derive(Clone, Eq, PartialEq)]
+#[must_use]
 pub enum FunctionResult {
     /// The Convex value returned on a successful run of a Convex function
     Value(Value),


### PR DESCRIPTION
I think FunctionResult should have #[must_use], since not using the result from a query or mutation is probably an error. For instance, ignoring the FunctionResult from a mutation might mean you get silent errors.

There might be other opinions here, take this as a suggestion :)

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
